### PR TITLE
refactor!: replace pbkdf2 with scrypt

### DIFF
--- a/src/plugins/hashed-bearer-auth/index.js
+++ b/src/plugins/hashed-bearer-auth/index.js
@@ -37,9 +37,8 @@ async function plugin(server) {
 				// TODO: look at making this async with Promise.any and Array.map
 				/* istanbul ignore else */
 				if (
-					crypto
-						.pbkdf2Sync(key, token.salt, 1000, 64, "sha512")
-						.toString("hex") === token.hash
+					crypto.scryptSync(key, token.salt, 64).toString("hex") ===
+					token.hash
 				) {
 					authorized = true;
 					req.scopes = secJSON.parse(token.scopes);

--- a/src/routes/admin/access/bearer-token/index.js
+++ b/src/routes/admin/access/bearer-token/index.js
@@ -342,9 +342,7 @@ async function route(server, options) {
 				const key = `ydhfhir_${crypto.randomUUID().replace(/-/g, "_")}`;
 
 				const salt = crypto.randomBytes(16).toString("hex");
-				const hash = crypto
-					.pbkdf2Sync(key, salt, 1000, 64, "sha512")
-					.toString("hex");
+				const hash = crypto.scryptSync(key, salt, 64).toString("hex");
 
 				const results = await server.db.query(
 					accessPost({


### PR DESCRIPTION
BREAKING CHANGE: scrypt now used for hashing stored bearer tokens